### PR TITLE
Adding Basic tests for Trim operation

### DIFF
--- a/pyclip/__init__.py
+++ b/pyclip/__init__.py
@@ -1,0 +1,2 @@
+
+from .core.video import Video

--- a/pyclip/core/video.py
+++ b/pyclip/core/video.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+class Model:
+    pass
 
 class Video(Model):
 
-    def trim(self):
+    def trim(self, t_start: float, t_end: float | None = None, unit: str = "s") -> Video:
+        """
+        Returns a clip playing the content of the current clip
+        between times ``t_start`` and ``t_end``
+        """
         ...
 
     def mute(self, channels: int | list[int] | None = None):

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -8,6 +8,7 @@ References:
 
 import pyclip
 from pyclip import Trim
+
 import pytest
 
 @pytest.fixture

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -15,10 +15,6 @@ def mock_video() -> pyclip.Video:
     """Fixture to generate a mock video for testing."""
     return pyclip.RandomVideo()
 
-def test_sanity():
-    """Test sanity check."""
-    assert 1 == 1
-
 def test_trim(mock_video: pyclip.Video):
     """Test trimming a video using seconds as unit."""
     video = mock_video.trim(50, 1000)

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -1,22 +1,62 @@
-import src as pyclip
+"""
+Tests for the trim method of the Video class.
 
+References:
+    - https://zulko.github.io/moviepy/ref/Clip.html?highlight=subclip#moviepy.Clip.Clip.subclip
+
+"""
+
+import src as pyclip
+from src import Trim
 import pytest
 
-def test_sanity():
-    assert 1 == 1
-
 @pytest.fixture
-def mock_video():
+def mock_video() -> pyclip.Video:
+    """Fixture to generate a mock video for testing."""
     return pyclip.RandomVideo()
 
-def test_trim(mock_video):
+def test_sanity():
+    """Test sanity check."""
+    assert 1 == 1
+
+def test_trim(mock_video: pyclip.Video):
+    """Test trimming a video using seconds as unit."""
     video = mock_video.trim(50, 1000)
     assert video.duration == 950
 
-def test_trim_by_frames(mock_video):
+def test_trim_by_frames(mock_video: pyclip.Video):
+    """Test trimming a video using frames as unit."""
     assert mock_video.trim(50, 100, unit="f") == mock_video[50:100]
 
-def test_trim_negative(mock_video):
+def test_trim_negative(mock_video: pyclip.Video):
+    """Test trimming with negative start frame raises a ValueError."""
     with pytest.raises(ValueError):
         mock_video.trim(-100, 1000, unit="f")
 
+def test_trim_class_operation(mock_video: pyclip.Video):
+    """Test using Trim class operation to trim a video."""
+    transforms = [
+        Trim(50, 100, unit="f")
+    ]
+
+    assert mock_video.apply(transforms) == mock_video.trim(50, 100, unit="f")
+
+def test_trim_start_greater_than_end(mock_video: pyclip.Video):
+    """Test trimming with start time greater than end time raises a ValueError."""
+    with pytest.raises(ValueError):
+        mock_video.trim(1000, 100)
+
+def test_trim_exceed_duration(mock_video: pyclip.Video):
+    """Test trimming with time range exceeding video duration raises an IndexError."""
+    with pytest.raises(IndexError):
+        mock_video.trim(0, mock_video.duration + 1000)
+
+def test_trim_invalid_unit(mock_video: pyclip.Video):
+    """Test trimming with invalid unit raises a ValueError."""
+    with pytest.raises(ValueError):
+        mock_video.trim(0, 100, unit="z")
+
+def test_trim_without_end(mock_video: pyclip.Video):
+    """Test trimming without specifying end trims to the end of the video."""
+    trimmed = mock_video.trim(50)
+    assert trimmed.duration == mock_video.duration - 50


### PR DESCRIPTION
# Add Tests for Video Trimming in Video Class

## **Description:**

This pull request introduces a suite of tests for the `trim` method of the `Video` class. Our focus was to ensure that the trimming functionality works as expected across various scenarios, thereby enhancing the reliability and robustness of our video editing library.

**Key Features and Changes:**
- Introduced a fixture `mock_video` that generates a mock video for consistent testing.
- Added basic sanity test to ensure the testing framework works as expected.
- Tested the `trim` method for:
  - Basic trimming using seconds as a unit.
  - Trimming using frames as a unit.
  - Handling of negative start frame values.
  - Using the `Trim` class operation for trimming.
  - Scenarios where the start time is greater than the end time.
  - Trimming ranges that exceed the video's duration.
  - Handling of invalid trimming units.
  - Trimming without specifying an end time, assuming it trims to the end of the video.

## **Reference:**
The tests were inspired and based on the official documentation from [MoviePy](https://zulko.github.io/moviepy/ref/Clip.html?highlight=subclip#moviepy.Clip.Clip.subclip).

## **Next Steps:**
Upon merging this pull request, we can proceed with the implementation of the `trim` method, ensuring it passes all these tests. Further, these tests will act as a safeguard against potential regressions in future updates.
