### PR TITLE
Tests for file opening, saving and conversion.

### DIFF
--- a/pyclip/__init__.py
+++ b/pyclip/__init__.py
@@ -1,0 +1,2 @@
+
+from .core.video import Video

--- a/pyclip/core/video.py
+++ b/pyclip/core/video.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+class Model:
+    pass
 
 class Video(Model):
 
-    def trim(self):
+    def trim(self, t_start: float, t_end: float | None = None, unit: str = "s") -> Video:
+        """
+        Returns a clip playing the content of the current clip
+        between times ``t_start`` and ``t_end``
+        """
         ...
 
     def mute(self, channels: int | list[int] | None = None):

--- a/pyclip/core/video.py
+++ b/pyclip/core/video.py
@@ -5,10 +5,10 @@ class Model:
 
 class Video(Model):
 
-    def trim(self, t_start: float, t_end: float | None = None, unit: str = "s") -> Video:
+    def trim(self, start: float, end: float | None = None, unit: str = "ms") -> Video:
         """
         Returns a clip playing the content of the current clip
-        between times ``t_start`` and ``t_end``
+        between times `start` and `end`
         """
         ...
 
@@ -19,4 +19,10 @@ class Video(Model):
         ...
 
     def upscale(self, **kwargs):
+        ...
+
+    def rand(self):
+        ...
+
+    def save(self, path: str | Path):
         ...

--- a/pyclip/core/video.py
+++ b/pyclip/core/video.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 class Model:
     pass
 
@@ -22,6 +24,9 @@ class Video(Model):
         ...
 
     def rand(self):
+        ...
+
+    def open(self, path: str | Path):
         ...
 
     def save(self, path: str | Path):

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,15 @@
+"""Conversion operation tests
+
+References: 
+    - https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save
+
+"""
+
+from pyclip import Video
+import tempfile
+
+def test_convert_to_mp4(mock_video: Video):
+    with tempfile.NamedTemporaryFile(suffix=".mp4") as f:
+        mock_video.save(f.name)
+
+    assert Video.from_file(f.name) == mock_video

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -8,8 +8,10 @@ References:
 from pyclip import Video
 import tempfile
 
-def test_convert_to_mp4(mock_video: Video):
-    with tempfile.NamedTemporaryFile(suffix=".mp4") as f:
-        mock_video.save(f.name)
+import pytest
 
-    assert Video.from_file(f.name) == mock_video
+@pytest.mark.parametrize("file_format", [("mp4"), ("avi")])
+def test_video_conversion(mock_video: Video, file_format: str):
+    with tempfile.NamedTemporaryFile(suffix=f".{file_format}") as f:
+        mock_video.save(f.name, format=file_format.upper())
+        assert Video.open(f.name) == mock_video

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -8,6 +8,7 @@ References:
 
 import pyclip
 from pyclip import Trim
+
 import pytest
 
 @pytest.fixture

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -15,10 +15,6 @@ def mock_video() -> pyclip.Video:
     """Fixture to generate a mock video for testing."""
     return pyclip.RandomVideo()
 
-def test_sanity():
-    """Test sanity check."""
-    assert 1 == 1
-
 def test_trim(mock_video: pyclip.Video):
     """Test trimming a video using seconds as unit."""
     video = mock_video.trim(50, 1000)

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -14,7 +14,7 @@ import pytest
 @pytest.fixture
 def mock_video() -> pyclip.Video:
     """Fixture to generate a mock video for testing."""
-    return pyclip.RandomVideo()
+    return pyclip.Video.rand()
 
 def test_trim(mock_video: pyclip.Video):
     """Test trimming a video using seconds as unit."""

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -1,22 +1,62 @@
-import src as pyclip
+"""
+Tests for the trim method of the Video class.
 
+References:
+    - https://zulko.github.io/moviepy/ref/Clip.html?highlight=subclip#moviepy.Clip.Clip.subclip
+
+"""
+
+import src as pyclip
+from src import Trim
 import pytest
 
-def test_sanity():
-    assert 1 == 1
-
 @pytest.fixture
-def mock_video():
+def mock_video() -> pyclip.Video:
+    """Fixture to generate a mock video for testing."""
     return pyclip.RandomVideo()
 
-def test_trim(mock_video):
+def test_sanity():
+    """Test sanity check."""
+    assert 1 == 1
+
+def test_trim(mock_video: pyclip.Video):
+    """Test trimming a video using seconds as unit."""
     video = mock_video.trim(50, 1000)
     assert video.duration == 950
 
-def test_trim_by_frames(mock_video):
+def test_trim_by_frames(mock_video: pyclip.Video):
+    """Test trimming a video using frames as unit."""
     assert mock_video.trim(50, 100, unit="f") == mock_video[50:100]
 
-def test_trim_negative(mock_video):
+def test_trim_negative(mock_video: pyclip.Video):
+    """Test trimming with negative start frame raises a ValueError."""
     with pytest.raises(ValueError):
         mock_video.trim(-100, 1000, unit="f")
 
+def test_trim_class_operation(mock_video: pyclip.Video):
+    """Test using Trim class operation to trim a video."""
+    transforms = [
+        Trim(50, 100, unit="f")
+    ]
+
+    assert mock_video.apply(transforms) == mock_video.trim(50, 100, unit="f")
+
+def test_trim_start_greater_than_end(mock_video: pyclip.Video):
+    """Test trimming with start time greater than end time raises a ValueError."""
+    with pytest.raises(ValueError):
+        mock_video.trim(1000, 100)
+
+def test_trim_exceed_duration(mock_video: pyclip.Video):
+    """Test trimming with time range exceeding video duration raises an IndexError."""
+    with pytest.raises(IndexError):
+        mock_video.trim(0, mock_video.duration + 1000)
+
+def test_trim_invalid_unit(mock_video: pyclip.Video):
+    """Test trimming with invalid unit raises a ValueError."""
+    with pytest.raises(ValueError):
+        mock_video.trim(0, 100, unit="z")
+
+def test_trim_without_end(mock_video: pyclip.Video):
+    """Test trimming without specifying end trims to the end of the video."""
+    trimmed = mock_video.trim(50)
+    assert trimmed.duration == mock_video.duration - 50


### PR DESCRIPTION
This PR simplifies and enhances our video conversion tests using pytest.mark.parametrize.

## Highlights:

Merged separate tests for .mp4 and .avi conversion into a unified test_video_conversion function.
Utilized pytest.mark.parametrize to iterate over different video formats, allowing for efficient test execution and easier future expansion to other formats.
Retained the use of temporary files to ensure no residual data remains during testing.
The changes were inspired by the desire to reduce code repetition and ensure our testing framework remains scalable.

References:

[Pillow Documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save)
Your feedback and reviews are highly appreciated.